### PR TITLE
Support jsons in Android format

### DIFF
--- a/src/components/ExposeChecker.vue
+++ b/src/components/ExposeChecker.vue
@@ -42,6 +42,11 @@
         class="mb-5 mt-10"
         cols="12"
       >
+            <v-radio-group v-model="os">
+              <v-radio key="ios" label="iOS" value="ios"></v-radio>
+              <v-radio key="android" label="Android" value="android"></v-radio>
+            </v-radio-group>
+
             <v-textarea 
               v-model=exposeJsonText
               outlined
@@ -107,25 +112,42 @@
     methods:{
       checkJson: function(){
         try {
-          const exposeData = JSON.parse( this.exposeJsonText)
-          const exposeDataArray = exposeData.ExposureChecks
+          if (this.os === "ios") {
+            const exposeData = JSON.parse( this.exposeJsonText)
+            const exposeDataArray = exposeData.ExposureChecks
 
-          this.resultJsonText = exposeDataArray
-          let resultJsonText = ""
-          let resultCount = 0
-          exposeDataArray.forEach(checkItem => {
-            checkItem.Files.forEach(file => {
-              if(file.MatchCount != 0){
-                resultJsonText += JSON.stringify(file,null,2) +",\n"
-                resultCount += 1
-              }
+            this.resultJsonText = exposeDataArray
+            let resultJsonText = ""
+            let resultCount = 0
+            exposeDataArray.forEach(checkItem => {
+              checkItem.Files.forEach(file => {
+                if(file.MatchCount != 0){
+                  resultJsonText += JSON.stringify(file,null,2) +",\n"
+                  resultCount += 1
+                }
+              });
             });
-          });
-          this.resultJsonText = resultJsonText
-          if(resultCount ==0){
-            this.resultText = "陽性者が近くにいた記録はありませんでした。"
-          }else{
-            this.resultText = resultCount + "件の陽性者が近くにいた記録が確認されました。"
+            this.resultJsonText = resultJsonText
+            if(resultCount ==0){
+              this.resultText = "陽性者が近くにいた記録はありませんでした。"
+            }else{
+              this.resultText = resultCount + "件の陽性者が近くにいた記録が確認されました。"
+            }
+          } else if (this.os === "android") {
+            const exposeData = JSON.parse(this.exposeJsonText)
+            const matchedExposures = exposeData.reduce((acc, exposure) => {
+              if (exposure.matchesCount !== 0) {
+                acc.push(exposure)
+              }
+              return acc
+            }, [])
+
+            if (matchedExposures.length === 0) {
+              this.resultText = "陽性者が近くにいた記録はありませんでした。"
+            } else {
+              this.resultText = `${matchedExposures.length}件の陽性者が近くにいた記録が確認されました。`
+              this.resultJsonText = matchedExposures.map(e => JSON.stringify(e)).join("\n")
+            }
           }
         } catch (error) {
           alert("データフォーマットエラー");
@@ -137,6 +159,7 @@
     },
     data: function(){
       return {
+        os: 'ios',
         resultJsonText: "",
         resultText: "",
         exposeJsonText: "",


### PR DESCRIPTION
Android でも同じような json の出力が可能なので対応させました
iOS デバイスが手元になく、iOS でどのようなフォーマットの json が出てくるのか正確にはわからなかったため、とりあえずラジオボタンで iOS/Android を選択させて処理を分岐させています
既存のコードから察する限りでは iOS のものには JSON のトップレベルに `ExporsureChecks: Array` があり、Android ではこの配列そのものがトップレベルにあるような雰囲気なので、この `ExposureChecks` の有無を見て自動的に処理を変えることも可能かもしれません

参考までに、Android で出力される json は以下のようなものです
テストなどにご利用ください

```
[
  {
    "timestamp": "August 9, 2021, 12:29",
    "keyCount": 2985,
    "matchesCount": 0,
    "appName": "COVID-19 Contact App",
    "hash": "hoge"
  },
  {
    "timestamp": "August 8, 2021, 01:50",
    "keyCount": 2967,
    "matchesCount": 1,
    "appName": "COVID-19 Contact App",
    "hash": "hoge"
  },
  {
    "timestamp": "August 7, 2021, 16:18",
    "keyCount": 2619,
    "matchesCount": 0,
    "appName": "COVID-19 Contact App",
    "hash": "hoge"
  },
  {
    "timestamp": "August 6, 2021, 03:53",
    "keyCount": 1941,
    "matchesCount": 1,
    "appName": "COVID-19 Contact App",
    "hash": "hoge"
  },
  {
    "timestamp": "August 5, 2021, 15:29",
    "keyCount": 1631,
    "matchesCount": 0,
    "appName": "COVID-19 Contact App",
    "hash": "hoge"
  }
]

```