### PR TITLE
Auto deploy to Github Pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,28 @@
+name: Deploy to Github Pages
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs


### PR DESCRIPTION
不要でしたら遠慮なくクローズしてください:bow:
masterブランチへ差分をコミットすると自動でGithub Pagesへデプロイするワークフローを追加しました。
この差分がマージされると、手元でビルドしてdocsの差分をコミットに含める必要がなくなります。

マージ後に１つWebUI上で作業が必要で、Github Pagesの対象ブランチを `gh-pages` の `/(root)` に変更する必要があります。
この `gh-pages` ブランチはCI上で自動で作成・更新されるものになります。

↓参考画像↓
<img width="567" alt="スクリーンショット 2021-08-21 21 25 14" src="https://user-images.githubusercontent.com/37956167/130321998-ac619f29-38f4-48a1-a1c9-2101454a1a75.png">

