### PR TITLE
fix twitter card image delete cache

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
     <meta property="og:url" content="https://ktansai.github.io/COVID-19-ExposeChecker"/> 
     <meta property="og:title" content="COCOAログチェッカー" />
     <meta property="og:description" content="iOS/Androidの内の約2週間の接触通知のログを解析し、自分の周りに陽性者が何人いたかを表示します。" /> 
-    <meta property="og:image" content="https://cocoa-log-checker.s3.ap-northeast-1.amazonaws.com/twitter-card.jpg" /> 
+    <meta property="og:image" content="https://cocoa-log-checker.s3.ap-northeast-1.amazonaws.com/twitter-card.jpg?1" /> 
 
 
 


### PR DESCRIPTION
Twitter の cardの画像がキャッシュされてしまっているので、更新するために、リンクを若干変えた。
https://www.iscle.com/web-it/twitter-card-cache.html
