### PR TITLE
delete display android timestamp

### DIFF
--- a/src/components/ExposeChecker.vue
+++ b/src/components/ExposeChecker.vue
@@ -217,6 +217,7 @@
             const exposeData = JSON.parse(this.exposeJsonText)
             const matchedExposures = exposeData.reduce((acc, exposure) => {
               if (exposure.matchesCount !== 0) {
+                delete exposure.timestamp
                 acc.push(exposure)
               }
               return acc


### PR DESCRIPTION
#17 と同様に、ここで表示されるタイムスタンプ = 接触日時と勘違いされてしまうので、暫定的に非表示にする。
https://twitter.com/info_kvaluation/status/1430818910224359424?s=20