### PR TITLE
接触通知データをクライアント側で処理している注意書きを追加 & 注意事項を読んでもらうように注意書きを追加

### DIFF
--- a/src/components/ExposeChecker.vue
+++ b/src/components/ExposeChecker.vue
@@ -10,9 +10,17 @@
       </v-row>
       <v-row class="justify-center">
         <div>
-        <p class="my-8 mx-8 ">
-          iOS/Androidの設定アプリから閲覧できる接触通知のログデータを解析し、<br>
-          約2週間の間にCOCOA上の陽性者登録者との接触通知のログを表示します。
+        <p class="my-8 mx-8">
+          <span class="d-inline-block">iOS/Androidの設定アプリから閲覧できる</span>
+          <span class="d-inline-block">接触通知のログデータを解析し、</span>
+          <span class="d-inline-block">約2週間の間にCOCOA上の陽性者登録者との</span>
+          <span class="d-inline-block">接触通知のログを表示します。</span>
+        </p>
+        <p class="my-8 mx-8">
+          <span class="d-inline-block">
+          使用の際は、事前に下記の注意事項/詳細説明を読み、
+          </span>
+          <span class="d-inline-block">理解した上でご利用ください。</span>
         </p>
         <p style="color:red;" class="mb-8">
           Androidをご利用の方へ:<br>
@@ -87,6 +95,10 @@
             >
             </v-textarea>
       </v-row>
+      <p class="text-caption">
+        <span class="d-inline-block">本ツールは、スマホ内で処理しているため、</span>
+        <span class="d-inline-block">ここでペーストしたデータが外部に流出することはありません。</span>
+      </p>
       <v-row class="mb-10 justify-center">
         <v-col cols="6"> 
           <v-btn


### PR DESCRIPTION
注意事項には予め、接触通知のログをサーバーにアップロードしていないことを書いていたが、
注意事項を読んでもらえない場合があったり、誤解を受けることがあったため、
接触通知のログデータをクライアントサイドのJavaScriptで処理していることを追加で記載。

また、使用の前に、注意事項を読んでもらうように促す文言をサイト上部に追加。