### PR TITLE
MatchCount等が存在しないデータをカウントしてしまう不具合の修正

### DIFF
--- a/src/components/ExposeChecker.vue
+++ b/src/components/ExposeChecker.vue
@@ -241,7 +241,7 @@
             let matchedExposures = []
             exposeDataArray.forEach(checkItem => {
               checkItem.Files.forEach(file => {
-                if(file.MatchCount !== 0){
+                if(file.MatchCount > 0){
                   delete file.Timestamp
                   matchedExposures.push(file)
                 }
@@ -258,7 +258,7 @@
           } else if (this.os === "android") {
             const exposeData = JSON.parse(this.exposeJsonText)
             const matchedExposures = exposeData.reduce((acc, exposure) => {
-              if (exposure.matchesCount !== 0) {
+              if (exposure.matchesCount > 0) {
                 delete exposure.timestamp
                 acc.push(exposure)
               }


### PR DESCRIPTION
MatchCount等のフィールドが存在しない場合，`undefined !== 0` を評価するためそのまま接触履歴としてカウントされてしまっていたようです．
`> 0` で評価すればそのまま無視できると思うのですがいかがでしょうか．

Closes #57