### PR TITLE
COCOA2.0.0 の iOSへの影響について説明書き(暫定対応)

### DIFF
--- a/src/components/ExposeChecker.vue
+++ b/src/components/ExposeChecker.vue
@@ -88,7 +88,17 @@
                 </v-expansion-panel-content>
             </v-expansion-panel>
             </v-expansion-panels>
-      </v-row>
+            <v-row class="justify-center" >
+              <div class="my-12 mx-2" style="width:90%">
+                <span style="color:red;">重要なお知らせ</span><br> 
+                <div style="text-align:left">
+                COCOAのアップデート(2.0.0)に伴い、iOSの設定画面から取得できるログデータの仕様が変更になり、アプリのアップデート後に蓄積されたログはCOCOAログチェッカーでの解析が不可能になりました。<br>
+                iOS端末では、アプリのアップデート後に新規陽性者とすれ違っていたとしても、COCOAログチェッカーの結果には反映されませんのでご注意ください。<br>
+                <a target="_blank" href="https://twitter.com/ktansai/status/1512377351950127111" >詳しい説明へ</a>
+                </div>
+              </div>
+            </v-row>
+        </v-row>
 
       <v-row >
 


### PR DESCRIPTION
COCOA2.0.0のアップデートの影響で、`ExposureChecks-*.json` から `MatchCount` の項目が消えていて、
ログ解析が不可になったことの説明(iOSのみ)

- https://twitter.com/ktansai/status/1512377351950127111
- https://github.com/cocoa-mhlw/cocoa/discussions/921#discussioncomment-2392052