### PR TITLE
2週間の期間が一部正しくない場合がある問題の修正

### DIFF
--- a/src/components/ExposeCheckerV2.vue
+++ b/src/components/ExposeCheckerV2.vue
@@ -418,7 +418,8 @@ export default {
         const exposeData = JSON.parse(this.sourceJsonText);
 
         const fromDate = new Date();
-        fromDate.setDate(fromDate.getDate() - 14);
+        fromDate.setDate(fromDate.getDate() - 13);
+        fromDate.setHours(8);
         const fromEpochMillis = fromDate.getTime();
 
         let checkLogResult;
@@ -512,7 +513,7 @@ export default {
     inspectionPeriod: function () {
       const today = new Date();
       const fromDate = new Date();
-      fromDate.setDate(today.getDate() - 14);
+      fromDate.setDate(today.getDate() - 13);
       return `${dateToString(today)} ~ ${dateToString(fromDate)}`;
     },
   },

--- a/src/components/ExposeCheckerV2.vue
+++ b/src/components/ExposeCheckerV2.vue
@@ -254,7 +254,8 @@
         </v-simple-table>
         <p class="text-left text-caption">
           期間:{{ inspectionPeriod }} (2週間)<br />
-          ※1件のカウント条件については<a href="#FAQ">FAQ</a>をご覧ください。
+          ※1件のカウント条件については<a href="#FAQ">よくある質問</a>をご覧ください。<br>
+          ※陽性登録者とのすれ違いの記録のなかった日は表示されません。
         </p>
         <br />
         <div align="left">


### PR DESCRIPTION
## 2週間の期間関係の話
### ①結果の表示は 2週間より長い場合があった(Date() を取得した(実行した時刻が残っていたため))
9時以降に実行すると、取得できるDateの時刻が9時以降なので、14日前の日の記録も含まれないが、
9時以前に実行すると、取得できるDateの時刻が9時以前なので、14日目の日の記録も含まる。

### ②結果の下の期間の表示が2週間+1日になっていた。
`2022/08/03〜2022/08/17 (2週間)` と表示されているが、実際には15日間で、2週間ではなかった。

## 説明文の修正
- 非表示の日について、説明文を加えた。
- ログがなかった日に関してはグレーアウトして、0件とか表示したほうが良いのかもしれない。

