### PR TITLE
文言を修正

### DIFF
--- a/src/components/ExposeCheckerV2.vue
+++ b/src/components/ExposeCheckerV2.vue
@@ -515,7 +515,7 @@ export default {
       const today = new Date();
       const fromDate = new Date();
       fromDate.setDate(today.getDate() - 13);
-      return `${dateToString(today)} ~ ${dateToString(fromDate)}`;
+      return `${dateToString(fromDate)} ~ ${dateToString(today)}`;
     },
   },
 };


### PR DESCRIPTION
期間について、過去~現在 の表記の方が自然に思われるため
（あくまでも提案ですが）